### PR TITLE
Upgrade simple_logger to 2.3.0 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "1.9.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "simple_logger"
-version = "1.16.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45b60258a35dc3cb8a16890b8fd6723349bfa458d7960e25e633f1b1c19d7b5e"
+checksum = "48047e77b528151aaf841a10a9025f9459da80ba820e425ff7eb005708a76dc7"
 dependencies = [
  "atty",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rusqlite = "0.25.0"
 scoped_threadpool = "0.1.9"
 serde = {version="1.0.125", features=["derive"]}
 serde_json = "1.0.64"
-simple_logger = "1.11.0"
+simple_logger = "2.3.0"
 walkdir = "2.3.2"
 dirs = "3.0.1"
 humantime = "2.1.0"


### PR DESCRIPTION
Fixes error  `Could not determine the UTC offset on this system` described in following issues:
- https://github.com/ChrisMacNaughton/cargo-cacher/issues/20
- https://github.com/borntyping/rust-simple_logger/issues/52

In my case this error happens every time when running `cargo-cacher` in Kubernetes on CoreOS (even without "-d" option).